### PR TITLE
Fix TypeError on NetBox 4.6 list views (Django 6.0 format_html change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-14
+
+### Fixed
+
+- **`TypeError: args or kwargs must be provided.` on NetBox 4.6.x list views**: Affected `/plugins/maintenance-device/maintenance-plans/` and `/plugins/maintenance-device/upcoming/`. Root cause: Django 6.0 (shipped with NetBox 4.6) now raises `TypeError` when `django.utils.html.format_html()` is called without any positional / keyword arguments. Previous Django versions only emitted a `DeprecationWarning`.
+- Replaced 10 unsafe `format_html('<span ...>literal</span>')` calls in `netbox_maintenance_device/tables.py` with `mark_safe(...)` (already imported), since those strings are fully static and contain no user input. The one remaining `format_html('... {} ...', abs(days))` call uses a placeholder and a positional arg, which remains valid under Django 6.0.
+
+### Technical Details
+
+Files Modified:
+
+- `netbox_maintenance_device/tables.py` – Replaced `format_html(static_html)` with `mark_safe(static_html)` in `MaintenancePlanTable.render_status`, `UpcomingMaintenanceTable.render_days_until`, `UpcomingMaintenanceTable.render_status`, and `UpcomingMaintenanceTable.render_actions`.
+- `netbox_maintenance_device/__init__.py` – Bumped `version` to `1.3.1`.
+- `pyproject.toml` – Bumped version to `1.3.1`.
+- `README.md` / `USAGE.md` / `CHANGELOG.md` – Version references updated.
+
 ## [1.3.0] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A comprehensive NetBox plugin for managing device preventive and corrective main
 | 4.0.x | **Likely Compatible** | Not officially tested |
 | 3.x | **Not Supported** | Breaking changes |
 
-> **Note**: This version (v1.3.0) is specifically tested and certified for NetBox 4.4.x, 4.5.x, and 4.6.x. While it may work with other 4.x versions, we recommend testing in a development environment first.
+> **Note**: This version (v1.3.1) is specifically tested and certified for NetBox 4.4.x, 4.5.x, and 4.6.x. While it may work with other 4.x versions, we recommend testing in a development environment first.
 
 > **Python Requirements**: NetBox 4.5.x and 4.6.x require Python 3.12, 3.13, or 3.14. NetBox 4.6.x also runs on Django 6.0. If you're using NetBox 4.4.x or earlier, you can use Python 3.8+.
 
@@ -51,12 +51,12 @@ A comprehensive NetBox plugin for managing device preventive and corrective main
 pip install netbox-maintenance-device
 
 # Or install a specific version
-pip install netbox-maintenance-device==1.3.0
+pip install netbox-maintenance-device==1.3.1
 ```
 
 **For Docker deployments**, add to your `plugin_requirements.txt`:
 ```bash
-echo "netbox-maintenance-device>=1.3.0" >> plugin_requirements.txt
+echo "netbox-maintenance-device>=1.3.1" >> plugin_requirements.txt
 ```
 
 ### Method 2: GitHub Installation

--- a/USAGE.md
+++ b/USAGE.md
@@ -310,5 +310,5 @@ For issues, feature requests, or questions:
 ---
 
 **Last Updated**: May 2026  
-**Plugin Version**: 1.3.0  
+**Plugin Version**: 1.3.1  
 **NetBox Compatibility**: 4.4.x, 4.5.x, 4.6.x

--- a/netbox_maintenance_device/__init__.py
+++ b/netbox_maintenance_device/__init__.py
@@ -5,7 +5,7 @@ class MaintenanceDeviceConfig(PluginConfig):
     name = 'netbox_maintenance_device'
     verbose_name = _('NetBox Device Maintenance')
     description = 'Manage device preventive and corrective maintenance with multilingual support'
-    version = '1.3.0'
+    version = '1.3.1'
     author = 'Diego Godoy'
     author_email = 'diegoalex-gdy@outlook.com'
     base_url = 'maintenance-device'
@@ -35,6 +35,6 @@ class MaintenanceDeviceConfig(PluginConfig):
         # to avoid issues during initial Django setup and collectstatic operations
         import logging
         logger = logging.getLogger(__name__)
-        logger.info("NetBox Maintenance Device v1.3.0 initialized successfully")
+        logger.info("NetBox Maintenance Device v1.3.1 initialized successfully")
 
 config = MaintenanceDeviceConfig

--- a/netbox_maintenance_device/tables.py
+++ b/netbox_maintenance_device/tables.py
@@ -29,19 +29,19 @@ class MaintenancePlanTable(NetBoxTable):
     
     def render_status(self, record):
         if not record.is_active:
-            return format_html('<span class="badge badge-secondary">Inactive</span>')
-        
+            return mark_safe('<span class="badge badge-secondary">Inactive</span>')
+
         if record.is_overdue():
-            return format_html('<span class="badge badge-danger">Overdue</span>')
-        
+            return mark_safe('<span class="badge badge-danger">Overdue</span>')
+
         days_until = record.days_until_due()
         if days_until is not None:
             if days_until <= 7:
-                return format_html('<span class="badge badge-warning">Due Soon</span>')
+                return mark_safe('<span class="badge badge-warning">Due Soon</span>')
             elif days_until <= 30:
-                return format_html('<span class="badge badge-info">Upcoming</span>')
-        
-        return format_html('<span class="badge badge-success">On Track</span>')
+                return mark_safe('<span class="badge badge-info">Upcoming</span>')
+
+        return mark_safe('<span class="badge badge-success">On Track</span>')
 
 
 class MaintenanceExecutionTable(NetBoxTable):
@@ -97,27 +97,27 @@ class UpcomingMaintenanceTable(NetBoxTable):
             if days < 0:
                 return format_html('<span class="text-danger"><i class="mdi mdi-alert-circle"></i> {} days overdue</span>', abs(days))
             elif days == 0:
-                return format_html('<span class="text-warning"><i class="mdi mdi-clock-alert"></i> Due today</span>')
+                return mark_safe('<span class="text-warning"><i class="mdi mdi-clock-alert"></i> Due today</span>')
             else:
                 return f"{days} days"
         return '-'
-    
+
     def render_status(self, record):
         # Use annotated field if available, otherwise calculate
         if hasattr(record, '_days_until'):
             days = record._days_until
         else:
             days = record.days_until_due()
-        
+
         if days is not None:
             if days < 0:
-                return format_html('<span class="badge badge-danger"><i class="mdi mdi-alert-circle"></i> Overdue</span>')
+                return mark_safe('<span class="badge badge-danger"><i class="mdi mdi-alert-circle"></i> Overdue</span>')
             elif days <= 7:
-                return format_html('<span class="badge badge-warning"><i class="mdi mdi-clock-alert"></i> Due Soon</span>')
+                return mark_safe('<span class="badge badge-warning"><i class="mdi mdi-clock-alert"></i> Due Soon</span>')
             else:
-                return format_html('<span class="badge badge-info">Upcoming</span>')
-        
-        return format_html('<span class="badge badge-success">On Track</span>')
+                return mark_safe('<span class="badge badge-info">Upcoming</span>')
+
+        return mark_safe('<span class="badge badge-success">On Track</span>')
     
     def render_actions(self, record):
         from django.utils.html import escape
@@ -157,4 +157,4 @@ class UpcomingMaintenanceTable(NetBoxTable):
                 '</button>'.format(pending_execution.pk, plan_name)
             )
         
-        return format_html(' '.join(actions)) if actions else '-'
+        return mark_safe(' '.join(actions)) if actions else '-'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-maintenance-device"
-version = "1.3.0"
+version = "1.3.1"
 description = "NetBox plugin for device maintenance management with comprehensive REST API and Portuguese-BR support"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Django 6.0 (shipped with NetBox 4.6) raises TypeError when format_html() is called without placeholders or args; previous versions only emitted a DeprecationWarning. This broke the maintenance-plans and upcoming list views with `TypeError: args or kwargs must be provided.`

Replaced 10 static `format_html('<span ...>literal</span>')` calls in tables.py with `mark_safe(...)`. The one remaining `format_html('... {} ...', abs(days))` call uses a placeholder and positional arg, so it stays valid under Django 6.0. Bumped plugin to v1.3.1 and updated docs.