### PR TITLE
Add virtual machine support and calendar-based scheduling (closes #14, #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-05-14
+
+### Added
+
+- **Virtual Machine support (#14)**: Maintenance plans can now target either a `dcim.Device` **or** a `virtualization.VirtualMachine`. A new "Maintenance" section appears on VM detail pages with the same UX as devices (active plans, recent activity, schedule / complete actions), plus a dedicated VM maintenance tab at `/plugins/maintenance-device/virtual-machine/<pk>/maintenance/`.
+- **Calendar-based scheduling (#15)**: Plans now have a `frequency_unit` (`days` / `weeks` / `months` / `quarters` / `years`) and an optional `anchor_date`. When `anchor_date` is set, the next maintenance is computed as `anchor_date + n * step` strictly after the last execution, eliminating the date drift that affected the legacy day-only schedules. Example: a quarterly plan anchored on Jan 1 stays on Jan 1 / Apr 1 / Jul 1 / Oct 1 indefinitely.
+- New `MaintenancePlan.target`, `target_type`, `target_name` helpers; `get_frequency_display()` for human-readable rendering in tables and templates.
+- API: `MaintenancePlanSerializer` exposes `virtual_machine`, `frequency_unit`, `anchor_date`, and `target_type`. `MaintenanceExecutionSerializer` exposes `virtual_machine`, `virtual_machine_id`, and `target_type` (legacy `device` / `device_id` fields remain for backward compatibility, now nullable). Filter sets accept `virtual_machine` / `virtual_machine_id` and `frequency_unit`.
+
+### Changed
+
+- **Schema**: `MaintenancePlan.device` is now nullable; new `virtual_machine` FK with the same `related_name='maintenance_plans'`; uniqueness rule replaced by two conditional `UniqueConstraint`s — name unique per device, and independently unique per VM.
+- `MaintenancePlan.frequency_days` is now a generic count (`Frequency`), interpreted via `frequency_unit`. Existing rows are preserved unchanged (default `frequency_unit='days'` means previous "Frequency (days)" semantics are kept on upgrade).
+- `UpcomingMaintenanceView` queryset no longer relies on SQL-side annotations for the next-due date (multi-unit / anchored math doesn't fit a single SQL expression); next-due / days-until are computed in Python via the model and the existing table fallback. `select_related` for `device` and `virtual_machine` added.
+- Tables, list views and detail templates now show a unified "Target" column with a Device / VM badge, an "Anchor" column and a human-readable "Frequency" column.
+
+### Migration
+
+- New `0003_virtual_machine_and_calendar_schedule` migration. Forward-compatible — existing day-based plans keep their behavior; no manual data migration required.
+
+### Closes
+
+- #14 (Feature request - supporting virtual devices)
+- #15 (Feature request - Support calendar-based scheduling)
+
 ## [1.3.1] - 2026-05-14
 
 ### Fixed

--- a/netbox_maintenance_device/__init__.py
+++ b/netbox_maintenance_device/__init__.py
@@ -5,7 +5,7 @@ class MaintenanceDeviceConfig(PluginConfig):
     name = 'netbox_maintenance_device'
     verbose_name = _('NetBox Device Maintenance')
     description = 'Manage device preventive and corrective maintenance with multilingual support'
-    version = '1.3.1'
+    version = '1.4.0'
     author = 'Diego Godoy'
     author_email = 'diegoalex-gdy@outlook.com'
     base_url = 'maintenance-device'
@@ -35,6 +35,6 @@ class MaintenanceDeviceConfig(PluginConfig):
         # to avoid issues during initial Django setup and collectstatic operations
         import logging
         logger = logging.getLogger(__name__)
-        logger.info("NetBox Maintenance Device v1.3.1 initialized successfully")
+        logger.info("NetBox Maintenance Device v1.4.0 initialized successfully")
 
 config = MaintenanceDeviceConfig

--- a/netbox_maintenance_device/admin.py
+++ b/netbox_maintenance_device/admin.py
@@ -1,16 +1,27 @@
 from django.contrib import admin
+
 from . import models
+
 
 @admin.register(models.MaintenancePlan)
 class MaintenancePlanAdmin(admin.ModelAdmin):
-    list_display = ['device', 'name', 'maintenance_type', 'frequency_days', 'is_active', 'created']
-    list_filter = ['maintenance_type', 'is_active', 'created']
-    search_fields = ['device__name', 'name', 'description']
-    ordering = ['device', 'name']
+    list_display = [
+        'name', 'device', 'virtual_machine', 'maintenance_type',
+        'frequency_days', 'frequency_unit', 'anchor_date', 'is_active', 'created',
+    ]
+    list_filter = ['maintenance_type', 'frequency_unit', 'is_active', 'created']
+    search_fields = ['device__name', 'virtual_machine__name', 'name', 'description']
+    ordering = ['device', 'virtual_machine', 'name']
+
 
 @admin.register(models.MaintenanceExecution)
 class MaintenanceExecutionAdmin(admin.ModelAdmin):
     list_display = ['maintenance_plan', 'scheduled_date', 'completed_date', 'status', 'technician']
     list_filter = ['status', 'completed', 'scheduled_date']
-    search_fields = ['maintenance_plan__device__name', 'maintenance_plan__name', 'technician']
+    search_fields = [
+        'maintenance_plan__device__name',
+        'maintenance_plan__virtual_machine__name',
+        'maintenance_plan__name',
+        'technician',
+    ]
     ordering = ['-scheduled_date']

--- a/netbox_maintenance_device/api/serializers.py
+++ b/netbox_maintenance_device/api/serializers.py
@@ -6,11 +6,20 @@ from django.utils import timezone
 
 class DeviceNestedSerializer(WritableNestedSerializer):
     """Nested serializer for Device references - NetBox 4.4.x compatible"""
-    
+
     class Meta:
         # Import Device model at class level
         from dcim import models as dcim_models
         model = dcim_models.Device
+        fields = ['id', 'url', 'display', 'name']
+
+
+class VirtualMachineNestedSerializer(WritableNestedSerializer):
+    """Nested serializer for VirtualMachine references."""
+
+    class Meta:
+        from virtualization import models as virt_models
+        model = virt_models.VirtualMachine
         fields = ['id', 'url', 'display', 'name']
 
 
@@ -44,71 +53,86 @@ class MaintenancePlanSerializer(NetBoxModelSerializer):
     )
     
     # Nested relationships
-    device = DeviceNestedSerializer()
+    device = DeviceNestedSerializer(required=False, allow_null=True)
+    virtual_machine = VirtualMachineNestedSerializer(required=False, allow_null=True)
     executions = NestedMaintenanceExecutionSerializer(many=True, read_only=True)
-    
+
     # Computed fields
     execution_count = serializers.IntegerField(read_only=True)
     next_maintenance_date = serializers.DateTimeField(read_only=True)
     is_overdue = serializers.BooleanField(read_only=True)
     days_until_due = serializers.IntegerField(read_only=True)
     last_execution_date = serializers.DateTimeField(read_only=True)
-    
+    target_type = serializers.CharField(read_only=True)
+
     class Meta:
         model = models.MaintenancePlan
         fields = [
-            'id', 'url', 'display', 'device', 'name', 'description', 
-            'maintenance_type', 'frequency_days', 'is_active',
+            'id', 'url', 'display', 'device', 'virtual_machine', 'name', 'description',
+            'maintenance_type', 'frequency_days', 'frequency_unit', 'anchor_date',
+            'is_active',
             'created', 'last_updated', 'custom_field_data', 'tags',
             # Relationships
             'executions', 'execution_count',
             # Computed fields
             'next_maintenance_date', 'is_overdue', 'days_until_due',
-            'last_execution_date'
+            'last_execution_date', 'target_type',
         ]
-        
+
     def validate_frequency_days(self, value):
-        """Validate frequency days is positive and reasonable"""
-        if value <= 0:
-            raise serializers.ValidationError("Frequency must be greater than 0 days")
-        if value > 3650:  # 10 years
-            raise serializers.ValidationError("Frequency cannot exceed 3650 days (10 years)")
+        """Validate frequency count is positive."""
+        if value is None or value <= 0:
+            raise serializers.ValidationError("Frequency must be greater than 0")
         return value
-    
+
     def validate(self, data):
-        """Additional model-level validations"""
-        device = data.get('device')
-        name = data.get('name')
-        
-        # Check for duplicate plan names per device (excluding current instance)
-        if device and name:
-            existing_plans = models.MaintenancePlan.objects.filter(
-                device=device, name=name
+        """Cross-field validation: exactly one target, unique name per target."""
+        # `data` carries only the fields submitted; merge with instance for partial updates.
+        device = data.get('device', getattr(self.instance, 'device', None))
+        vm = data.get('virtual_machine', getattr(self.instance, 'virtual_machine', None))
+        name = data.get('name', getattr(self.instance, 'name', None))
+
+        if device and vm:
+            raise serializers.ValidationError(
+                "Pick either a device or a virtual machine, not both."
             )
+        if not device and not vm:
+            raise serializers.ValidationError(
+                "A maintenance plan must reference either a device or a virtual machine."
+            )
+
+        if name:
+            target_filter = {'device': device} if device else {'virtual_machine': vm}
+            existing_plans = models.MaintenancePlan.objects.filter(name=name, **target_filter)
             if self.instance:
                 existing_plans = existing_plans.exclude(pk=self.instance.pk)
-            
+
             if existing_plans.exists():
+                target_label = 'device' if device else 'virtual machine'
                 raise serializers.ValidationError({
-                    'name': f"A maintenance plan with name '{name}' already exists for this device."
+                    'name': (
+                        f"A maintenance plan with name '{name}' already exists "
+                        f"for this {target_label}."
+                    )
                 })
-        
+
         return data
     
     def to_representation(self, instance):
         """Add computed fields to the representation"""
         data = super().to_representation(instance)
-        
+
         # Add computed fields
         data['execution_count'] = instance.executions.count()
         data['next_maintenance_date'] = instance.get_next_maintenance_date()
         data['is_overdue'] = instance.is_overdue()
         data['days_until_due'] = instance.days_until_due()
-        
+        data['target_type'] = instance.target_type
+
         # Add last execution date
         last_execution = instance.executions.filter(completed=True).order_by('-completed_date').first()
         data['last_execution_date'] = last_execution.completed_date if last_execution else None
-        
+
         return data
 
 
@@ -122,20 +146,28 @@ class MaintenanceExecutionSerializer(NetBoxModelSerializer):
     # Nested relationships
     maintenance_plan = NestedMaintenancePlanSerializer()
     
-    # Computed fields
-    device = serializers.CharField(source='maintenance_plan.device.name', read_only=True)
-    device_id = serializers.IntegerField(source='maintenance_plan.device.id', read_only=True)
+    # Computed fields — kept for backward compatibility with existing API consumers.
+    device = serializers.CharField(source='maintenance_plan.device.name', read_only=True, default=None)
+    device_id = serializers.IntegerField(source='maintenance_plan.device.id', read_only=True, default=None)
+    virtual_machine = serializers.CharField(
+        source='maintenance_plan.virtual_machine.name', read_only=True, default=None,
+    )
+    virtual_machine_id = serializers.IntegerField(
+        source='maintenance_plan.virtual_machine.id', read_only=True, default=None,
+    )
+    target_type = serializers.CharField(source='maintenance_plan.target_type', read_only=True)
     plan_name = serializers.CharField(source='maintenance_plan.name', read_only=True)
     duration_days = serializers.SerializerMethodField()
-    
+
     class Meta:
         model = models.MaintenanceExecution
         fields = [
-            'id', 'url', 'display', 'maintenance_plan', 'scheduled_date', 
+            'id', 'url', 'display', 'maintenance_plan', 'scheduled_date',
             'completed_date', 'status', 'notes', 'technician', 'completed',
             'created', 'last_updated', 'custom_field_data', 'tags',
             # Computed fields
-            'device', 'device_id', 'plan_name', 'duration_days'
+            'device', 'device_id', 'virtual_machine', 'virtual_machine_id',
+            'target_type', 'plan_name', 'duration_days',
         ]
     
     def get_duration_days(self, obj):

--- a/netbox_maintenance_device/api/views.py
+++ b/netbox_maintenance_device/api/views.py
@@ -24,11 +24,11 @@ from .permissions import (
 
 class MaintenancePlanFilter(filters.FilterSet):
     """Advanced filtering for MaintenancePlan API"""
-    
+
     # Device filters
     device_id = filters.ModelMultipleChoiceFilter(
         field_name='device',
-        queryset=lambda request: models.Device.objects.all(),
+        queryset=lambda request: __import__('dcim.models', fromlist=['Device']).Device.objects.all(),
         label='Device (ID)',
     )
     device = filters.CharFilter(
@@ -36,11 +36,29 @@ class MaintenancePlanFilter(filters.FilterSet):
         lookup_expr='icontains',
         label='Device (name)',
     )
-    
+
+    # Virtual machine filters
+    virtual_machine_id = filters.ModelMultipleChoiceFilter(
+        field_name='virtual_machine',
+        queryset=lambda request: __import__(
+            'virtualization.models', fromlist=['VirtualMachine']
+        ).VirtualMachine.objects.all(),
+        label='Virtual Machine (ID)',
+    )
+    virtual_machine = filters.CharFilter(
+        field_name='virtual_machine__name',
+        lookup_expr='icontains',
+        label='Virtual Machine (name)',
+    )
+
     # Maintenance type filters
     maintenance_type = filters.MultipleChoiceFilter(
         choices=models.MaintenancePlan.MAINTENANCE_TYPE_CHOICES,
         label='Maintenance Type',
+    )
+    frequency_unit = filters.MultipleChoiceFilter(
+        choices=models.MaintenancePlan.FREQUENCY_UNIT_CHOICES,
+        label='Frequency Unit',
     )
     
     # Frequency filters
@@ -91,14 +109,15 @@ class MaintenancePlanFilter(filters.FilterSet):
         """Full-text search across multiple fields"""
         if not value.strip():
             return queryset
-        
+
         return queryset.filter(
             Q(name__icontains=value) |
             Q(description__icontains=value) |
             Q(device__name__icontains=value) |
-            Q(device__serial__icontains=value)
+            Q(device__serial__icontains=value) |
+            Q(virtual_machine__name__icontains=value)
         ).distinct()
-    
+
     class Meta:
         model = models.MaintenancePlan
         fields = []
@@ -122,13 +141,27 @@ class MaintenanceExecutionFilter(filters.FilterSet):
     # Device filters (through plan)
     device_id = filters.ModelMultipleChoiceFilter(
         field_name='maintenance_plan__device',
-        queryset=lambda request: models.Device.objects.all(),
+        queryset=lambda request: __import__('dcim.models', fromlist=['Device']).Device.objects.all(),
         label='Device (ID)',
     )
     device = filters.CharFilter(
         field_name='maintenance_plan__device__name',
         lookup_expr='icontains',
         label='Device (name)',
+    )
+
+    # Virtual machine filters (through plan)
+    virtual_machine_id = filters.ModelMultipleChoiceFilter(
+        field_name='maintenance_plan__virtual_machine',
+        queryset=lambda request: __import__(
+            'virtualization.models', fromlist=['VirtualMachine']
+        ).VirtualMachine.objects.all(),
+        label='Virtual Machine (ID)',
+    )
+    virtual_machine = filters.CharFilter(
+        field_name='maintenance_plan__virtual_machine__name',
+        lookup_expr='icontains',
+        label='Virtual Machine (name)',
     )
     
     # Status filters
@@ -189,10 +222,11 @@ class MaintenanceExecutionFilter(filters.FilterSet):
         """Full-text search across multiple fields"""
         if not value.strip():
             return queryset
-        
+
         return queryset.filter(
             Q(maintenance_plan__name__icontains=value) |
             Q(maintenance_plan__device__name__icontains=value) |
+            Q(maintenance_plan__virtual_machine__name__icontains=value) |
             Q(notes__icontains=value) |
             Q(technician__icontains=value)
         ).distinct()
@@ -205,7 +239,9 @@ class MaintenanceExecutionFilter(filters.FilterSet):
 class MaintenancePlanViewSet(NetBoxModelViewSet):
     """Complete API ViewSet for MaintenancePlan with advanced features"""
     
-    queryset = models.MaintenancePlan.objects.select_related('device').prefetch_related(
+    queryset = models.MaintenancePlan.objects.select_related(
+        'device', 'virtual_machine'
+    ).prefetch_related(
         'tags',
         Prefetch('executions', queryset=models.MaintenanceExecution.objects.order_by('-scheduled_date'))
     )
@@ -215,13 +251,16 @@ class MaintenancePlanViewSet(NetBoxModelViewSet):
     
     # Ordering options
     ordering_fields = [
-        'id', 'name', 'device__name', 'maintenance_type', 
-        'frequency_days', 'is_active', 'created', 'last_updated'
+        'id', 'name', 'device__name', 'virtual_machine__name', 'maintenance_type',
+        'frequency_days', 'frequency_unit', 'is_active', 'created', 'last_updated',
     ]
-    ordering = ['device__name', 'name']
+    ordering = ['device__name', 'virtual_machine__name', 'name']
     
     # Search fields for basic search
-    search_fields = ['name', 'description', 'device__name', 'device__serial']
+    search_fields = [
+        'name', 'description', 'device__name', 'device__serial',
+        'virtual_machine__name',
+    ]
     
     def get_queryset(self):
         """Optimize queryset with annotations for computed fields"""
@@ -329,7 +368,8 @@ class MaintenanceExecutionViewSet(NetBoxModelViewSet):
     
     queryset = models.MaintenanceExecution.objects.select_related(
         'maintenance_plan',
-        'maintenance_plan__device'
+        'maintenance_plan__device',
+        'maintenance_plan__virtual_machine',
     ).prefetch_related('tags')
     serializer_class = MaintenanceExecutionSerializer
     filterset_class = MaintenanceExecutionFilter
@@ -337,16 +377,19 @@ class MaintenanceExecutionViewSet(NetBoxModelViewSet):
     
     # Ordering options
     ordering_fields = [
-        'id', 'scheduled_date', 'completed_date', 'status', 
+        'id', 'scheduled_date', 'completed_date', 'status',
         'maintenance_plan__name', 'maintenance_plan__device__name',
-        'technician', 'created', 'last_updated'
+        'maintenance_plan__virtual_machine__name',
+        'technician', 'created', 'last_updated',
     ]
     ordering = ['-scheduled_date']
     
     # Search fields for basic search
     search_fields = [
-        'maintenance_plan__name', 'maintenance_plan__device__name',
-        'notes', 'technician'
+        'maintenance_plan__name',
+        'maintenance_plan__device__name',
+        'maintenance_plan__virtual_machine__name',
+        'notes', 'technician',
     ]
     
     @action(detail=True, methods=['post'], permission_classes=[CanCompleteMaintenance])

--- a/netbox_maintenance_device/forms.py
+++ b/netbox_maintenance_device/forms.py
@@ -1,39 +1,77 @@
-from django import forms
-from django.utils.translation import gettext_lazy as _
-from netbox.forms import NetBoxModelForm
-from dcim.models import Device
-from utilities.forms.fields import DynamicModelChoiceField
 import django_filters
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from dcim.models import Device
 from netbox.filtersets import NetBoxModelFilterSet
+from netbox.forms import NetBoxModelForm
+from utilities.forms.fields import DynamicModelChoiceField
+from virtualization.models import VirtualMachine
+
 from . import models
 
 
 class MaintenancePlanForm(NetBoxModelForm):
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
-        selector=True
+        required=False,
+        selector=True,
+        label=_('Device'),
+        help_text=_("Pick a device — or pick a virtual machine below, not both."),
     )
-    
+    virtual_machine = DynamicModelChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        selector=True,
+        label=_('Virtual Machine'),
+        help_text=_("Pick a virtual machine — or pick a device above, not both."),
+    )
+
     class Meta:
         model = models.MaintenancePlan
         fields = [
-            'device', 'name', 'description', 'maintenance_type', 
-            'frequency_days', 'is_active', 'tags'
+            'device', 'virtual_machine', 'name', 'description', 'maintenance_type',
+            'frequency_days', 'frequency_unit', 'anchor_date', 'is_active', 'tags',
         ]
+        widgets = {
+            'anchor_date': forms.DateInput(attrs={'type': 'date'}),
+        }
+
+    def clean(self):
+        cleaned_data = super().clean()
+        device = cleaned_data.get('device')
+        vm = cleaned_data.get('virtual_machine')
+        if device and vm:
+            raise ValidationError(_(
+                "Pick either a device or a virtual machine, not both."
+            ))
+        if not device and not vm:
+            raise ValidationError(_(
+                "Pick a device or a virtual machine for this plan."
+            ))
+        return cleaned_data
 
 
 class MaintenancePlanFilterSet(NetBoxModelFilterSet):
     device = django_filters.ModelChoiceFilter(
         queryset=Device.objects.all(),
-        field_name='device'
+        field_name='device',
+    )
+    virtual_machine = django_filters.ModelChoiceFilter(
+        queryset=VirtualMachine.objects.all(),
+        field_name='virtual_machine',
     )
     maintenance_type = django_filters.ChoiceFilter(
         choices=models.MaintenancePlan.MAINTENANCE_TYPE_CHOICES
     )
-    
+    frequency_unit = django_filters.ChoiceFilter(
+        choices=models.MaintenancePlan.FREQUENCY_UNIT_CHOICES
+    )
+
     class Meta:
         model = models.MaintenancePlan
-        fields = ['device', 'maintenance_type', 'is_active']
+        fields = ['device', 'virtual_machine', 'maintenance_type', 'frequency_unit', 'is_active']
 
 
 class MaintenanceExecutionForm(NetBoxModelForm):
@@ -41,7 +79,7 @@ class MaintenanceExecutionForm(NetBoxModelForm):
         queryset=models.MaintenancePlan.objects.all(),
         selector=True
     )
-    
+
     class Meta:
         model = models.MaintenanceExecution
         fields = [
@@ -62,7 +100,7 @@ class MaintenanceExecutionFilterSet(NetBoxModelFilterSet):
     status = django_filters.ChoiceFilter(
         choices=models.MaintenanceExecution.STATUS_CHOICES
     )
-    
+
     class Meta:
         model = models.MaintenanceExecution
         fields = ['maintenance_plan', 'status', 'completed']

--- a/netbox_maintenance_device/migrations/0003_virtual_machine_and_calendar_schedule.py
+++ b/netbox_maintenance_device/migrations/0003_virtual_machine_and_calendar_schedule.py
@@ -1,0 +1,127 @@
+"""Add VirtualMachine support and calendar-based scheduling.
+
+This migration:
+
+- Makes ``MaintenancePlan.device`` nullable.
+- Adds ``MaintenancePlan.virtual_machine`` (FK to ``virtualization.VirtualMachine``).
+- Adds ``MaintenancePlan.frequency_unit`` (days/weeks/months/quarters/years).
+- Adds ``MaintenancePlan.anchor_date`` (nullable; enables drift-free schedules).
+- Drops any pre-existing ``unique_together`` constraint on
+  ``(device, name)`` and replaces it with two conditional ``UniqueConstraint``\
+  s — one per target type — so the uniqueness rule is preserved across both
+  Device and VirtualMachine targets.
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_maintenance_device', '0002_cleanup_notifications'),
+        ('dcim', '__latest__'),
+        ('virtualization', '__latest__'),
+    ]
+
+    operations = [
+        # Clear the old (device, name) unique_together so we can switch to
+        # per-target conditional UniqueConstraints below. This is a no-op if
+        # the database never had it applied.
+        migrations.AlterUniqueTogether(
+            name='maintenanceplan',
+            unique_together=set(),
+        ),
+        # Make device nullable: a plan can now target either a device OR a VM.
+        migrations.AlterField(
+            model_name='maintenanceplan',
+            name='device',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='maintenance_plans',
+                to='dcim.device',
+                verbose_name='Device',
+            ),
+        ),
+        # Add virtual_machine FK.
+        migrations.AddField(
+            model_name='maintenanceplan',
+            name='virtual_machine',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='maintenance_plans',
+                to='virtualization.virtualmachine',
+                verbose_name='Virtual Machine',
+            ),
+        ),
+        # Add calendar-based scheduling fields.
+        migrations.AddField(
+            model_name='maintenanceplan',
+            name='frequency_unit',
+            field=models.CharField(
+                choices=[
+                    ('days', 'Days'),
+                    ('weeks', 'Weeks'),
+                    ('months', 'Months'),
+                    ('quarters', 'Quarters'),
+                    ('years', 'Years'),
+                ],
+                default='days',
+                max_length=20,
+                verbose_name='Frequency Unit',
+            ),
+        ),
+        migrations.AddField(
+            model_name='maintenanceplan',
+            name='anchor_date',
+            field=models.DateField(
+                blank=True,
+                help_text=(
+                    "Optional anchor date. When set, future maintenances are "
+                    "computed from this date instead of from the last "
+                    "execution, preventing calendar drift (useful for 'start "
+                    "of each quarter' schedules)."
+                ),
+                null=True,
+                verbose_name='Anchor Date',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='maintenanceplan',
+            name='frequency_days',
+            field=models.PositiveIntegerField(
+                help_text='Number of frequency units between maintenances',
+                verbose_name='Frequency',
+            ),
+        ),
+        migrations.AlterModelOptions(
+            name='maintenanceplan',
+            options={
+                'ordering': ['device', 'virtual_machine', 'name'],
+                'verbose_name': 'Maintenance Plan',
+                'verbose_name_plural': 'Maintenance Plans',
+            },
+        ),
+        # Per-target uniqueness: plan name must be unique within each device,
+        # and within each virtual machine, independently.
+        migrations.AddConstraint(
+            model_name='maintenanceplan',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(('device__isnull', False)),
+                fields=('device', 'name'),
+                name='unique_device_plan_name',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='maintenanceplan',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(('virtual_machine__isnull', False)),
+                fields=('virtual_machine', 'name'),
+                name='unique_vm_plan_name',
+            ),
+        ),
+    ]

--- a/netbox_maintenance_device/models.py
+++ b/netbox_maintenance_device/models.py
@@ -1,25 +1,59 @@
+from datetime import datetime, time, timedelta
+
+from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from datetime import timedelta
-from netbox.models import NetBoxModel
+
 from dcim.models import Device
+from netbox.models import NetBoxModel
+from virtualization.models import VirtualMachine
+
+
+# Max iterations when stepping forward from an anchor_date to the next due date.
+# Bounds the loop so a degenerate (zero-width) step can never spin forever.
+_ANCHOR_STEP_MAX_ITERATIONS = 10000
 
 
 class MaintenancePlan(NetBoxModel):
-    """Maintenance plan for a device with frequency and type"""
-    
+    """Maintenance plan for a device or a virtual machine.
+
+    A plan targets exactly one of `device` or `virtual_machine`. Scheduling is
+    expressed as a (`frequency_days`, `frequency_unit`) pair, optionally
+    anchored to `anchor_date` to avoid calendar drift (e.g. "start of each
+    quarter").
+    """
+
     MAINTENANCE_TYPE_CHOICES = [
         ('preventive', _('Preventive')),
         ('corrective', _('Corrective')),
     ]
-    
+
+    FREQUENCY_UNIT_CHOICES = [
+        ('days', _('Days')),
+        ('weeks', _('Weeks')),
+        ('months', _('Months')),
+        ('quarters', _('Quarters')),
+        ('years', _('Years')),
+    ]
+
     device = models.ForeignKey(
         Device,
         on_delete=models.CASCADE,
         related_name='maintenance_plans',
-        verbose_name=_('Device')
+        null=True,
+        blank=True,
+        verbose_name=_('Device'),
+    )
+    virtual_machine = models.ForeignKey(
+        VirtualMachine,
+        on_delete=models.CASCADE,
+        related_name='maintenance_plans',
+        null=True,
+        blank=True,
+        verbose_name=_('Virtual Machine'),
     )
     name = models.CharField(max_length=100, verbose_name=_('Name'))
     description = models.TextField(blank=True, verbose_name=_('Description'))
@@ -27,53 +61,149 @@ class MaintenancePlan(NetBoxModel):
         max_length=20,
         choices=MAINTENANCE_TYPE_CHOICES,
         default='preventive',
-        verbose_name=_('Maintenance Type')
+        verbose_name=_('Maintenance Type'),
     )
     frequency_days = models.PositiveIntegerField(
-        help_text=_("Frequency in days"),
-        verbose_name=_('Frequency (days)')
+        help_text=_("Number of frequency units between maintenances"),
+        verbose_name=_('Frequency'),
+    )
+    frequency_unit = models.CharField(
+        max_length=20,
+        choices=FREQUENCY_UNIT_CHOICES,
+        default='days',
+        verbose_name=_('Frequency Unit'),
+    )
+    anchor_date = models.DateField(
+        null=True,
+        blank=True,
+        help_text=_(
+            "Optional anchor date. When set, future maintenances are computed "
+            "from this date instead of from the last execution, preventing "
+            "calendar drift (useful for 'start of each quarter' schedules)."
+        ),
+        verbose_name=_('Anchor Date'),
     )
     is_active = models.BooleanField(default=True, verbose_name=_('Active'))
-    
+
     class Meta:
-        ordering = ['device', 'name']
-        unique_together = ['device', 'name']
+        ordering = ['device', 'virtual_machine', 'name']
         verbose_name = _('Maintenance Plan')
         verbose_name_plural = _('Maintenance Plans')
-    
+        constraints = [
+            models.UniqueConstraint(
+                fields=['device', 'name'],
+                condition=models.Q(device__isnull=False),
+                name='unique_device_plan_name',
+            ),
+            models.UniqueConstraint(
+                fields=['virtual_machine', 'name'],
+                condition=models.Q(virtual_machine__isnull=False),
+                name='unique_vm_plan_name',
+            ),
+        ]
+
+    @property
+    def target(self):
+        """Return the assigned Device or VirtualMachine (whichever is set)."""
+        return self.device or self.virtual_machine
+
+    @property
+    def target_type(self):
+        """Return 'device', 'virtualmachine', or None."""
+        if self.device_id:
+            return 'device'
+        if self.virtual_machine_id:
+            return 'virtualmachine'
+        return None
+
+    @property
+    def target_name(self):
+        target = self.target
+        return target.name if target else ''
+
+    def clean(self):
+        super().clean()
+        has_device = self.device_id is not None
+        has_vm = self.virtual_machine_id is not None
+        if has_device and has_vm:
+            raise ValidationError(_(
+                "A maintenance plan cannot reference both a device and a "
+                "virtual machine; pick one."
+            ))
+        if not has_device and not has_vm:
+            raise ValidationError(_(
+                "A maintenance plan must reference either a device or a "
+                "virtual machine."
+            ))
+
     def __str__(self):
-        return f"{self.device.name} - {self.name}"
-    
+        return f"{self.target_name or _('(no target)')} - {self.name}"
+
     def get_absolute_url(self):
         return reverse('plugins:netbox_maintenance_device:maintenanceplan', args=[self.pk])
-    
-    def save(self, *args, **kwargs):
-        """Override save with basic safety checks."""
-        super().save(*args, **kwargs)
-    
-    def delete(self, *args, **kwargs):
-        """Override delete with basic safety checks."""
-        super().delete(*args, **kwargs)
-    
+
+    def get_frequency_display(self):
+        """Human-readable frequency string, e.g. '30 days' or 'Every 2 quarters'."""
+        count = self.frequency_days or 1
+        unit_label = dict(self.FREQUENCY_UNIT_CHOICES).get(self.frequency_unit, self.frequency_unit)
+        return f"{count} {unit_label}"
+
+    def _step_delta(self):
+        """Return a relativedelta representing one step between maintenances."""
+        count = self.frequency_days or 1
+        unit = self.frequency_unit or 'days'
+        if unit == 'weeks':
+            return relativedelta(weeks=count)
+        if unit == 'months':
+            return relativedelta(months=count)
+        if unit == 'quarters':
+            return relativedelta(months=count * 3)
+        if unit == 'years':
+            return relativedelta(years=count)
+        return relativedelta(days=count)
+
     def get_next_maintenance_date(self):
-        """Calculate next maintenance date based on last execution"""
+        """Compute the next scheduled maintenance date.
+
+        Two modes:
+
+        - Anchor mode (`anchor_date` is set): returns the smallest
+          `anchor_date + n * step` (n >= 0) that is strictly greater than the
+          reference date. This avoids drift over time, so a quarterly schedule
+          anchored on Jan 1 stays on Jan 1 / Apr 1 / Jul 1 / Oct 1 regardless
+          of when previous executions actually happened.
+        - Interval mode (no anchor): returns reference + step.
+
+        Reference date is the last completed execution's `completed_date`, or
+        the plan's `created` timestamp if there are no completed executions.
+        """
         last_execution = self.executions.filter(
             completed=True
         ).order_by('-completed_date').first()
-        
-        if last_execution:
-            return last_execution.completed_date + timedelta(days=self.frequency_days)
-        else:
-            # If no executions, use creation date as base
-            return self.created + timedelta(days=self.frequency_days)
-    
+        reference = last_execution.completed_date if last_execution else self.created
+
+        step = self._step_delta()
+
+        if self.anchor_date:
+            anchor_dt = timezone.make_aware(
+                datetime.combine(self.anchor_date, time.min)
+            )
+            if anchor_dt > reference:
+                return anchor_dt
+            candidate = anchor_dt
+            for _i in range(_ANCHOR_STEP_MAX_ITERATIONS):
+                candidate = candidate + step
+                if candidate > reference:
+                    return candidate
+            return candidate
+
+        return reference + step
+
     def is_overdue(self):
-        """Check if maintenance is overdue"""
         next_date = self.get_next_maintenance_date()
         return timezone.now().date() > next_date.date() if next_date else False
-    
+
     def days_until_due(self):
-        """Get days until next maintenance (negative if overdue)"""
         next_date = self.get_next_maintenance_date()
         if next_date:
             delta = next_date.date() - timezone.now().date()
@@ -83,14 +213,14 @@ class MaintenancePlan(NetBoxModel):
 
 class MaintenanceExecution(NetBoxModel):
     """Record of maintenance execution"""
-    
+
     STATUS_CHOICES = [
         ('scheduled', _('Scheduled')),
         ('in_progress', _('In Progress')),
         ('completed', _('Completed')),
         ('cancelled', _('Cancelled')),
     ]
-    
+
     maintenance_plan = models.ForeignKey(
         MaintenancePlan,
         on_delete=models.CASCADE,
@@ -108,18 +238,18 @@ class MaintenanceExecution(NetBoxModel):
     notes = models.TextField(blank=True, verbose_name=_('Notes'))
     technician = models.CharField(max_length=100, blank=True, verbose_name=_('Technician'))
     completed = models.BooleanField(default=False, verbose_name=_('Completed'))
-    
+
     class Meta:
         ordering = ['-scheduled_date']
         verbose_name = _('Maintenance Execution')
         verbose_name_plural = _('Maintenance Executions')
-    
+
     def __str__(self):
         return f"{self.maintenance_plan} - {self.scheduled_date.strftime('%Y-%m-%d')}"
-    
+
     def get_absolute_url(self):
         return reverse('plugins:netbox_maintenance_device:maintenanceexecution', args=[self.pk])
-    
+
     def save(self, *args, **kwargs):
         # Auto-set completed flag based on status
         self.completed = self.status == 'completed'

--- a/netbox_maintenance_device/tables.py
+++ b/netbox_maintenance_device/tables.py
@@ -1,32 +1,85 @@
 import django_tables2 as tables
-from django.utils.html import format_html
+from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
+
 from netbox.tables import NetBoxTable, columns
+
 from . import models
 
 
+def _render_target(record):
+    """Render a clickable link to the plan's device or virtual machine."""
+    target = record.target
+    if target is None:
+        return '-'
+    return format_html(
+        '<a href="{}">{}</a>',
+        target.get_absolute_url(),
+        target.name,
+    )
+
+
+def _render_target_type(record):
+    """Render a short badge identifying the target kind."""
+    target_type = record.target_type
+    if target_type == 'device':
+        return mark_safe(
+            '<span class="badge bg-secondary"><i class="mdi mdi-server"></i> Device</span>'
+        )
+    if target_type == 'virtualmachine':
+        return mark_safe(
+            '<span class="badge bg-info"><i class="mdi mdi-monitor"></i> VM</span>'
+        )
+    return '-'
+
+
 class MaintenancePlanTable(NetBoxTable):
-    device = tables.Column(linkify=True)
+    target = tables.Column(
+        empty_values=(),
+        verbose_name=_('Target'),
+        orderable=False,
+    )
+    target_type = tables.Column(
+        empty_values=(),
+        verbose_name=_('Type'),
+        orderable=False,
+    )
     name = tables.Column(linkify=True)
     maintenance_type = tables.Column()
-    frequency_days = tables.Column(verbose_name='Frequency (days)')
-    next_maintenance = tables.Column(empty_values=(), verbose_name='Next Due', orderable=False)
-    status = tables.Column(empty_values=(), verbose_name='Status', orderable=False)
+    frequency = tables.Column(
+        empty_values=(),
+        verbose_name=_('Frequency'),
+        orderable=False,
+    )
+    anchor_date = tables.Column(verbose_name=_('Anchor'))
+    next_maintenance = tables.Column(empty_values=(), verbose_name=_('Next Due'), orderable=False)
+    status = tables.Column(empty_values=(), verbose_name=_('Status'), orderable=False)
     is_active = columns.BooleanColumn()
-    
+
     class Meta(NetBoxTable.Meta):
         model = models.MaintenancePlan
-        fields = ('pk', 'device', 'name', 'maintenance_type', 'frequency_days', 
-                 'next_maintenance', 'status', 'is_active', 'created', 'last_updated')
-        default_columns = ('device', 'name', 'maintenance_type', 'frequency_days', 
-                          'next_maintenance', 'status', 'is_active')
-    
+        fields = ('pk', 'target', 'target_type', 'name', 'maintenance_type',
+                  'frequency', 'anchor_date', 'next_maintenance', 'status',
+                  'is_active', 'created', 'last_updated')
+        default_columns = ('target', 'target_type', 'name', 'maintenance_type',
+                           'frequency', 'next_maintenance', 'status', 'is_active')
+
+    def render_target(self, record):
+        return _render_target(record)
+
+    def render_target_type(self, record):
+        return _render_target_type(record)
+
+    def render_frequency(self, record):
+        return record.get_frequency_display()
+
     def render_next_maintenance(self, record):
         next_date = record.get_next_maintenance_date()
         if next_date:
             return next_date.strftime('%Y-%m-%d')
         return '-'
-    
+
     def render_status(self, record):
         if not record.is_active:
             return mark_safe('<span class="badge badge-secondary">Inactive</span>')
@@ -46,93 +99,118 @@ class MaintenancePlanTable(NetBoxTable):
 
 class MaintenanceExecutionTable(NetBoxTable):
     maintenance_plan = tables.Column(linkify=True)
-    device = tables.Column(accessor='maintenance_plan.device', linkify=True)
+    target = tables.Column(
+        empty_values=(),
+        verbose_name=_('Target'),
+        orderable=False,
+    )
     scheduled_date = columns.DateTimeColumn()
     completed_date = columns.DateTimeColumn()
     status = tables.Column()
     technician = tables.Column()
-    
+
     class Meta(NetBoxTable.Meta):
         model = models.MaintenanceExecution
-        fields = ('pk', 'maintenance_plan', 'device', 'scheduled_date', 
-                 'completed_date', 'status', 'technician', 'created', 'last_updated')
-        default_columns = ('maintenance_plan', 'device', 'scheduled_date', 
-                          'completed_date', 'status', 'technician')
+        fields = ('pk', 'maintenance_plan', 'target', 'scheduled_date',
+                  'completed_date', 'status', 'technician', 'created', 'last_updated')
+        default_columns = ('maintenance_plan', 'target', 'scheduled_date',
+                           'completed_date', 'status', 'technician')
+
+    def render_target(self, record):
+        return _render_target(record.maintenance_plan)
 
 
 class UpcomingMaintenanceTable(NetBoxTable):
-    device = tables.Column(linkify=True)
+    target = tables.Column(
+        empty_values=(),
+        verbose_name=_('Target'),
+        orderable=False,
+    )
+    target_type = tables.Column(
+        empty_values=(),
+        verbose_name=_('Type'),
+        orderable=False,
+    )
     name = tables.Column(linkify=True)
     maintenance_type = tables.Column()
-    next_due = tables.Column(empty_values=(), verbose_name='Next Due', order_by='_next_due_date')
-    days_until = tables.Column(empty_values=(), verbose_name='Days Until Due', order_by='_days_until')
-    status = tables.Column(empty_values=(), verbose_name='Status', order_by='_status_priority')
-    actions = tables.Column(empty_values=(), verbose_name='Actions', orderable=False)
-    
+    frequency = tables.Column(
+        empty_values=(),
+        verbose_name=_('Frequency'),
+        orderable=False,
+    )
+    next_due = tables.Column(empty_values=(), verbose_name=_('Next Due'), orderable=False)
+    days_until = tables.Column(empty_values=(), verbose_name=_('Days Until Due'), orderable=False)
+    status = tables.Column(empty_values=(), verbose_name=_('Status'), orderable=False)
+    actions = tables.Column(empty_values=(), verbose_name=_('Actions'), orderable=False)
+
     class Meta(NetBoxTable.Meta):
         model = models.MaintenancePlan
-        fields = ('pk', 'device', 'name', 'maintenance_type', 'next_due', 
-                 'days_until', 'status', 'actions')
-        default_columns = ('device', 'name', 'maintenance_type', 'next_due', 
-                          'days_until', 'status', 'actions')
-    
+        fields = ('pk', 'target', 'target_type', 'name', 'maintenance_type',
+                  'frequency', 'next_due', 'days_until', 'status', 'actions')
+        default_columns = ('target', 'target_type', 'name', 'maintenance_type',
+                           'frequency', 'next_due', 'days_until', 'status', 'actions')
+
+    def render_target(self, record):
+        return _render_target(record)
+
+    def render_target_type(self, record):
+        return _render_target_type(record)
+
+    def render_frequency(self, record):
+        return record.get_frequency_display()
+
     def render_next_due(self, record):
-        # Try to use annotated field first, fallback to method
-        if hasattr(record, '_next_due_date') and record._next_due_date:
-            return record._next_due_date.strftime('%Y-%m-%d')
-        
-        next_date = record.get_next_maintenance_date()
+        next_date = getattr(record, '_next_due_date', None) or record.get_next_maintenance_date()
         if next_date:
             return next_date.strftime('%Y-%m-%d')
         return '-'
-    
+
     def render_days_until(self, record):
-        # Try to use annotated field first, fallback to method
-        if hasattr(record, '_days_until'):
-            days = record._days_until
-        else:
+        days = getattr(record, '_days_until', None)
+        if days is None:
             days = record.days_until_due()
-        
+
         if days is not None:
             if days < 0:
-                return format_html('<span class="text-danger"><i class="mdi mdi-alert-circle"></i> {} days overdue</span>', abs(days))
+                return format_html(
+                    '<span class="text-danger">'
+                    '<i class="mdi mdi-alert-circle"></i> {} days overdue</span>',
+                    abs(days),
+                )
             elif days == 0:
-                return mark_safe('<span class="text-warning"><i class="mdi mdi-clock-alert"></i> Due today</span>')
+                return mark_safe(
+                    '<span class="text-warning">'
+                    '<i class="mdi mdi-clock-alert"></i> Due today</span>'
+                )
             else:
                 return f"{days} days"
         return '-'
 
     def render_status(self, record):
-        # Use annotated field if available, otherwise calculate
-        if hasattr(record, '_days_until'):
-            days = record._days_until
-        else:
+        days = getattr(record, '_days_until', None)
+        if days is None:
             days = record.days_until_due()
 
         if days is not None:
             if days < 0:
-                return mark_safe('<span class="badge badge-danger"><i class="mdi mdi-alert-circle"></i> Overdue</span>')
+                return mark_safe(
+                    '<span class="badge badge-danger">'
+                    '<i class="mdi mdi-alert-circle"></i> Overdue</span>'
+                )
             elif days <= 7:
-                return mark_safe('<span class="badge badge-warning"><i class="mdi mdi-clock-alert"></i> Due Soon</span>')
+                return mark_safe(
+                    '<span class="badge badge-warning">'
+                    '<i class="mdi mdi-clock-alert"></i> Due Soon</span>'
+                )
             else:
                 return mark_safe('<span class="badge badge-info">Upcoming</span>')
 
         return mark_safe('<span class="badge badge-success">On Track</span>')
-    
+
     def render_actions(self, record):
-        from django.utils.html import escape
         actions = []
-        
-        # Use annotated field if available, otherwise calculate
-        if hasattr(record, '_days_until'):
-            days_until = record._days_until
-        else:
-            days_until = record.days_until_due()
-        
-        # Escape plan name to prevent issues with special characters
         plan_name = escape(record.name)
-        
-        # Schedule button - sempre disponível para planos ativos
+
         actions.append(
             '<button type="button" class="btn btn-sm btn-outline-primary schedule-btn mr-1 maintenance-action-btn" '
             'data-plan-id="{}" data-plan-name="{}" '
@@ -141,12 +219,11 @@ class UpcomingMaintenanceTable(NetBoxTable):
             '<i class="mdi mdi-calendar-plus"></i> Schedule'
             '</button>'.format(record.pk, plan_name)
         )
-        
-        # Complete button - apenas se houver agendamento pendente (scheduled ou in_progress)
+
         pending_execution = record.executions.filter(
             status__in=['scheduled', 'in_progress']
         ).order_by('scheduled_date').first()
-        
+
         if pending_execution:
             actions.append(
                 '<button type="button" class="btn btn-sm btn-success quick-complete-btn maintenance-action-btn" '
@@ -156,5 +233,5 @@ class UpcomingMaintenanceTable(NetBoxTable):
                 '<i class="mdi mdi-check-circle"></i> Complete'
                 '</button>'.format(pending_execution.pk, plan_name)
             )
-        
+
         return mark_safe(' '.join(actions)) if actions else '-'

--- a/netbox_maintenance_device/template_content.py
+++ b/netbox_maintenance_device/template_content.py
@@ -1,62 +1,88 @@
 from netbox.plugins import PluginTemplateExtension
-from dcim.models import Device
+
 from . import models
 
-class DeviceMaintenanceExtension(PluginTemplateExtension):
-    """Add maintenance information to device detail page"""
-    models = ['dcim.device']
-    
-    def left_page(self):
-        """Add maintenance section to the left side of device page"""
-        return self.render('netbox_maintenance_device/device_maintenance_section.html', extra_context=self._get_maintenance_context())
-    
-    def buttons(self):
-        """Add maintenance buttons to device page"""
-        return self.render('netbox_maintenance_device/device_maintenance_buttons.html', extra_context=self._get_maintenance_context())
-    
-    def _get_maintenance_context(self):
-        """Get maintenance context for the device"""
-        if hasattr(self, 'context') and 'object' in self.context:
-            device = self.context['object']
-            maintenance_plans = models.MaintenancePlan.objects.filter(device=device)
-            recent_executions = models.MaintenanceExecution.objects.filter(
-                maintenance_plan__device=device
-            ).order_by('-scheduled_date')[:5]
-            
-            # Count maintenance status and add pending execution info
-            overdue_count = 0
-            due_soon_count = 0
-            total_active = 0
-            
-            # Enrich plans with pending execution information
-            plans_with_execution = []
-            for plan in maintenance_plans:
-                # Get pending execution for this plan
-                pending_execution = models.MaintenanceExecution.objects.filter(
-                    maintenance_plan=plan,
-                    status__in=['scheduled', 'in_progress']
-                ).order_by('scheduled_date').first()
-                
-                # Add pending execution as attribute to the plan object
-                plan.pending_execution = pending_execution
-                plans_with_execution.append(plan)
-                
-                if plan.is_active:
-                    total_active += 1
-                    if plan.is_overdue():
-                        overdue_count += 1
-                    else:
-                        days_until = plan.days_until_due()
-                        if days_until and days_until <= 7 and days_until > 0:
-                            due_soon_count += 1
-            
-            return {
-                'maintenance_plans': plans_with_execution,
-                'recent_executions': recent_executions,
-                'overdue_count': overdue_count,
-                'due_soon_count': due_soon_count,
-                'total_active_plans': total_active,
-            }
-        return {}
 
-template_extensions = [DeviceMaintenanceExtension]
+class _MaintenanceExtensionMixin:
+    """Shared logic for surfacing maintenance info on device / VM detail pages."""
+
+    target_kwarg = None  # 'device' or 'virtual_machine'
+    tab_url_name = None  # URL name for the dedicated maintenance tab page
+
+    def _get_maintenance_context(self):
+        target = self.context.get('object') if hasattr(self, 'context') else None
+        if target is None:
+            return {}
+
+        plan_filter = {self.target_kwarg: target}
+        execution_filter = {f'maintenance_plan__{self.target_kwarg}': target}
+
+        maintenance_plans = list(models.MaintenancePlan.objects.filter(**plan_filter))
+        recent_executions = models.MaintenanceExecution.objects.filter(
+            **execution_filter
+        ).order_by('-scheduled_date')[:5]
+
+        overdue_count = 0
+        due_soon_count = 0
+        total_active = 0
+
+        plans_with_execution = []
+        for plan in maintenance_plans:
+            pending_execution = models.MaintenanceExecution.objects.filter(
+                maintenance_plan=plan,
+                status__in=['scheduled', 'in_progress']
+            ).order_by('scheduled_date').first()
+
+            plan.pending_execution = pending_execution
+            plans_with_execution.append(plan)
+
+            if plan.is_active:
+                total_active += 1
+                if plan.is_overdue():
+                    overdue_count += 1
+                else:
+                    days_until = plan.days_until_due()
+                    if days_until and 0 < days_until <= 7:
+                        due_soon_count += 1
+
+        return {
+            'maintenance_plans': plans_with_execution,
+            'recent_executions': recent_executions,
+            'overdue_count': overdue_count,
+            'due_soon_count': due_soon_count,
+            'total_active_plans': total_active,
+            'target_kwarg': self.target_kwarg,
+            'maintenance_tab_url_name': self.tab_url_name,
+        }
+
+    def left_page(self):
+        return self.render(
+            'netbox_maintenance_device/device_maintenance_section.html',
+            extra_context=self._get_maintenance_context(),
+        )
+
+    def buttons(self):
+        return self.render(
+            'netbox_maintenance_device/device_maintenance_buttons.html',
+            extra_context=self._get_maintenance_context(),
+        )
+
+
+class DeviceMaintenanceExtension(_MaintenanceExtensionMixin, PluginTemplateExtension):
+    """Add maintenance info to the device detail page."""
+    models = ['dcim.device']
+    target_kwarg = 'device'
+    tab_url_name = 'plugins:netbox_maintenance_device:device_maintenance_tab'
+
+
+class VirtualMachineMaintenanceExtension(_MaintenanceExtensionMixin, PluginTemplateExtension):
+    """Add maintenance info to the virtual machine detail page."""
+    models = ['virtualization.virtualmachine']
+    target_kwarg = 'virtual_machine'
+    tab_url_name = 'plugins:netbox_maintenance_device:virtualmachine_maintenance_tab'
+
+
+template_extensions = [
+    DeviceMaintenanceExtension,
+    VirtualMachineMaintenanceExtension,
+]

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/device_maintenance_buttons.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/device_maintenance_buttons.html
@@ -18,7 +18,7 @@
 {% endif %}
 
 {% if perms.netbox_maintenance_device.add_maintenanceexecution %}
-<a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_add' %}?device={{ object.pk }}" class="btn btn-sm btn-primary">
+<a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_add' %}?{{ target_kwarg|default:'device' }}={{ object.pk }}" class="btn btn-sm btn-primary">
     <i class="mdi mdi-wrench" aria-hidden="true"></i> {% trans "Add Execution" %}
 </a>
 {% endif %}

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/device_maintenance_section.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/device_maintenance_section.html
@@ -74,7 +74,7 @@
                 </div>
             </div>
             <div class="mt-3 text-center">
-                <a href="{% url 'plugins:netbox_maintenance_device:device_maintenance_tab' pk=object.pk %}" class="btn btn-sm btn-outline-primary">
+                <a href="{% url maintenance_tab_url_name|default:'plugins:netbox_maintenance_device:device_maintenance_tab' pk=object.pk %}" class="btn btn-sm btn-outline-primary">
                     <i class="mdi mdi-calendar-clock"></i> {% trans "View All Maintenance" %}
                 </a>
             </div>
@@ -82,7 +82,7 @@
             <div class="text-center">
                 <p class="text-muted mb-2">{% trans "No maintenance plans configured" %}</p>
                 {% if perms.netbox_maintenance_device.add_maintenanceplan %}
-                    <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?device={{ object.pk }}" class="btn btn-sm btn-primary">
+                    <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?{{ target_kwarg|default:'device' }}={{ object.pk }}" class="btn btn-sm btn-primary">
                         <i class="mdi mdi-plus-thick"></i> {% trans "Add Plan" %}
                     </a>
                 {% endif %}

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/device_maintenance_tab.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/device_maintenance_tab.html
@@ -16,7 +16,11 @@
             </h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{% url 'dcim:device_list' %}">{% trans "Devices" %}</a></li>
+                    {% if target_kind == 'virtualmachine' %}
+                        <li class="breadcrumb-item"><a href="{% url 'virtualization:virtualmachine_list' %}">{% trans "Virtual Machines" %}</a></li>
+                    {% else %}
+                        <li class="breadcrumb-item"><a href="{% url 'dcim:device_list' %}">{% trans "Devices" %}</a></li>
+                    {% endif %}
                     <li class="breadcrumb-item"><a href="{{ device.get_absolute_url }}">{{ device.name }}</a></li>
                     <li class="breadcrumb-item active">{% trans "Maintenance" %}</li>
                 </ol>
@@ -24,12 +28,12 @@
         </div>
         <div class="btn-group">
             {% if perms.netbox_maintenance_device.add_maintenanceplan %}
-                <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?device={{ device.pk }}" class="btn btn-primary">
+                <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?{% if target_kind == 'virtualmachine' %}virtual_machine{% else %}device{% endif %}={{ device.pk }}" class="btn btn-primary">
                     <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Plan" %}
                 </a>
             {% endif %}
             {% if perms.netbox_maintenance_device.add_maintenanceexecution %}
-                <a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_add' %}?device={{ device.pk }}" class="btn btn-outline-primary">
+                <a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_add' %}?{% if target_kind == 'virtualmachine' %}virtual_machine{% else %}device{% endif %}={{ device.pk }}" class="btn btn-outline-primary">
                     <i class="mdi mdi-wrench" aria-hidden="true"></i> {% trans "Add Execution" %}
                 </a>
             {% endif %}
@@ -45,7 +49,7 @@
                 <i class="mdi mdi-calendar-clock"></i> {% trans "Maintenance Plans" %}
                 <div class="card-actions">
                     {% if perms.netbox_maintenance_device.add_maintenanceplan %}
-                        <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?device={{ device.pk }}" class="btn btn-sm btn-primary">
+                        <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?{% if target_kind == 'virtualmachine' %}virtual_machine{% else %}device{% endif %}={{ device.pk }}" class="btn btn-sm btn-primary">
                             <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Plan" %}
                         </a>
                     {% endif %}
@@ -69,7 +73,7 @@
                             <tr {% if plan.is_overdue %}class="table-danger"{% elif plan.days_until_due and plan.days_until_due <= 7 %}class="table-warning"{% endif %}>
                                 <td><a href="{{ plan.get_absolute_url }}">{{ plan.name }}</a></td>
                                 <td>{{ plan.get_maintenance_type_display }}</td>
-                                <td>{{ plan.frequency_days }} {% trans "days" %}</td>
+                                <td>{{ plan.get_frequency_display }}</td>
                                 <td>
                                     {% with next_date=plan.get_next_maintenance_date %}
                                         {% if next_date %}
@@ -117,7 +121,7 @@
                         <i class="mdi mdi-information"></i>
                         {% trans "No maintenance plans configured for this device." %}
                         {% if perms.netbox_maintenance_device.add_maintenanceplan %}
-                            <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?device={{ device.pk }}" class="btn btn-sm btn-primary ml-2">
+                            <a href="{% url 'plugins:netbox_maintenance_device:maintenanceplan_add' %}?{% if target_kind == 'virtualmachine' %}virtual_machine{% else %}device{% endif %}={{ device.pk }}" class="btn btn-sm btn-primary ml-2">
                                 <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Plan" %}
                             </a>
                         {% endif %}
@@ -189,7 +193,7 @@
                         </tbody>
                     </table>
                     <div class="text-center mt-3">
-                        <a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_list' %}?maintenance_plan__device={{ device.pk }}" class="btn btn-outline-primary">
+                        <a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_list' %}?maintenance_plan__{% if target_kind == 'virtualmachine' %}virtual_machine{% else %}device{% endif %}={{ device.pk }}" class="btn btn-outline-primary">
                             <i class="mdi mdi-history"></i> {% trans "View all maintenance history" %} →
                         </a>
                     </div>
@@ -198,7 +202,7 @@
                         <i class="mdi mdi-information"></i>
                         {% trans "No maintenance executions recorded for this device." %}
                         {% if perms.netbox_maintenance_device.add_maintenanceexecution %}
-                            <a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_add' %}?device={{ device.pk }}" class="btn btn-sm btn-primary ml-2">
+                            <a href="{% url 'plugins:netbox_maintenance_device:maintenanceexecution_add' %}?{% if target_kind == 'virtualmachine' %}virtual_machine{% else %}device{% endif %}={{ device.pk }}" class="btn btn-sm btn-primary ml-2">
                                 <i class="mdi mdi-wrench" aria-hidden="true"></i> {% trans "Add Execution" %}
                             </a>
                         {% endif %}

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceexecution.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceexecution.html
@@ -11,8 +11,21 @@
                     <td><a href="{{ object.maintenance_plan.get_absolute_url }}">{{ object.maintenance_plan }}</a></td>
                 </tr>
                 <tr>
-                    <td>Device</td>
-                    <td><a href="{{ object.maintenance_plan.device.get_absolute_url }}">{{ object.maintenance_plan.device }}</a></td>
+                    <td>Target</td>
+                    <td>
+                        {% with target=object.maintenance_plan.target %}
+                            {% if target %}
+                                <a href="{{ target.get_absolute_url }}">{{ target }}</a>
+                                {% if object.maintenance_plan.target_type == 'device' %}
+                                    <span class="badge bg-secondary ml-1"><i class="mdi mdi-server"></i> Device</span>
+                                {% else %}
+                                    <span class="badge bg-info ml-1"><i class="mdi mdi-monitor"></i> VM</span>
+                                {% endif %}
+                            {% else %}
+                                —
+                            {% endif %}
+                        {% endwith %}
+                    </td>
                 </tr>
                 <tr>
                     <td>Scheduled Date</td>

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceplan.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceplan.html
@@ -7,8 +7,19 @@
             <h5 class="card-header">Maintenance Plan Details</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <td>Device</td>
-                    <td><a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a></td>
+                    <td>Target</td>
+                    <td>
+                        {% if object.target %}
+                            <a href="{{ object.target.get_absolute_url }}">{{ object.target }}</a>
+                            {% if object.target_type == 'device' %}
+                                <span class="badge bg-secondary ml-1"><i class="mdi mdi-server"></i> Device</span>
+                            {% else %}
+                                <span class="badge bg-info ml-1"><i class="mdi mdi-monitor"></i> VM</span>
+                            {% endif %}
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
                 </tr>
                 <tr>
                     <td>Name</td>
@@ -24,7 +35,11 @@
                 </tr>
                 <tr>
                     <td>Frequency</td>
-                    <td>{{ object.frequency_days }} days</td>
+                    <td>{{ object.get_frequency_display }}</td>
+                </tr>
+                <tr>
+                    <td>Anchor Date</td>
+                    <td>{% if object.anchor_date %}{{ object.anchor_date|date:"Y-m-d" }}{% else %}—{% endif %}</td>
                 </tr>
                 <tr>
                     <td>Active</td>

--- a/netbox_maintenance_device/templatetags/maintenance_extras.py
+++ b/netbox_maintenance_device/templatetags/maintenance_extras.py
@@ -1,25 +1,27 @@
 from django import template
-from django.urls import reverse
+from django.db.models import Q
+
 from ..models import MaintenancePlan
 
 register = template.Library()
 
+
 @register.inclusion_tag('netbox_maintenance_device/device_maintenance_tab.html', takes_context=True)
-def device_maintenance_tab(context, device):
-    """Render maintenance tab for device detail view"""
-    maintenance_plans = MaintenancePlan.objects.filter(device=device)
+def device_maintenance_tab(context, target):
+    """Render maintenance tab for a device or virtual machine detail view."""
+    target_filter = Q(device=target) | Q(virtual_machine=target)
+    maintenance_plans = MaintenancePlan.objects.filter(target_filter)
+
     recent_executions = []
-    
     for plan in maintenance_plans:
-        executions = plan.executions.order_by('-scheduled_date')[:5]
-        recent_executions.extend(executions)
-    
-    # Sort all executions by date
+        recent_executions.extend(plan.executions.order_by('-scheduled_date')[:5])
+
     recent_executions.sort(key=lambda x: x.scheduled_date, reverse=True)
     recent_executions = recent_executions[:10]
-    
+
     return {
-        'device': device,
+        'device': target,
+        'target': target,
         'maintenance_plans': maintenance_plans,
         'recent_executions': recent_executions,
         'request': context['request'],

--- a/netbox_maintenance_device/urls.py
+++ b/netbox_maintenance_device/urls.py
@@ -25,6 +25,9 @@ urlpatterns = [
     
     # Device Tab
     path('device/<int:pk>/maintenance/', views.device_maintenance_tab, name='device_maintenance_tab'),
+
+    # Virtual Machine Tab
+    path('virtual-machine/<int:pk>/maintenance/', views.virtualmachine_maintenance_tab, name='virtualmachine_maintenance_tab'),
     
     # Quick Actions
     path('quick-complete/', views.quick_complete_maintenance, name='quick_complete'),

--- a/netbox_maintenance_device/views.py
+++ b/netbox_maintenance_device/views.py
@@ -10,6 +10,7 @@ from django.views.decorators.http import require_http_methods
 import json
 from netbox.views import generic
 from dcim.models import Device
+from virtualization.models import VirtualMachine
 from . import forms, models, tables
 
 
@@ -66,77 +67,16 @@ class UpcomingMaintenanceView(generic.ObjectListView):
     template_name = 'netbox_maintenance_device/upcoming_maintenance.html'
     
     def get_queryset(self, request):
-        from django.db.models import (
-            Case, When, Value, IntegerField, Subquery, OuterRef, F, 
-            ExpressionWrapper, DateTimeField, DurationField
+        # Active plans only. Next-due dates are computed in Python because the
+        # schedule logic now spans multiple units (days/weeks/months/quarters/years)
+        # and an optional anchor date, which can't be expressed cleanly as a single
+        # SQL expression. Tables fall back to model methods when the annotation
+        # fields are missing.
+        return (
+            super().get_queryset(request)
+            .select_related('device', 'virtual_machine')
+            .prefetch_related('executions')
         )
-        from django.db.models.functions import Cast, Coalesce, Extract
-        from datetime import timedelta
-        
-        # Get all active maintenance plans
-        queryset = super().get_queryset(request)
-        
-        # Subquery to get the last completed execution date for each plan
-        last_execution = models.MaintenanceExecution.objects.filter(
-            maintenance_plan=OuterRef('pk'),
-            completed=True
-        ).order_by('-completed_date')
-        
-        # Current time for calculations
-        now = timezone.now()
-        
-        # Annotate the queryset with calculated fields
-        queryset = queryset.annotate(
-            # Get last completed date
-            last_completed_date=Subquery(last_execution.values('completed_date')[:1]),
-            
-            # Calculate next maintenance date
-            # If there's a last execution, add frequency_days to it, otherwise add to created date
-            _next_due_date=Case(
-                When(
-                    last_completed_date__isnull=False,
-                    then=ExpressionWrapper(
-                        F('last_completed_date') + F('frequency_days') * timedelta(days=1),
-                        output_field=DateTimeField()
-                    )
-                ),
-                default=ExpressionWrapper(
-                    F('created') + F('frequency_days') * timedelta(days=1),
-                    output_field=DateTimeField()
-                ),
-                output_field=DateTimeField()
-            )
-        )
-        
-        # Second annotation for days_until calculation (depends on _next_due_date)
-        queryset = queryset.annotate(
-            # Calculate days until due (will be negative for overdue)
-            # Extract days from the duration
-            _days_until=Cast(
-                Extract(
-                    ExpressionWrapper(
-                        F('_next_due_date') - now,
-                        output_field=DurationField()
-                    ),
-                    'epoch'
-                ) / 86400,  # Convert seconds to days
-                output_field=IntegerField()
-            )
-        )
-        
-        # Third annotation for status priority (depends on _days_until)
-        queryset = queryset.annotate(
-            # Calculate status priority for sorting
-            # Overdue = 0, Due Soon (<=7 days) = 1, Upcoming = 2
-            _status_priority=Case(
-                When(_days_until__lt=0, then=Value(0)),  # Overdue (highest priority)
-                When(_days_until__lte=7, then=Value(1)), # Due Soon
-                default=Value(2),                         # Upcoming
-                output_field=IntegerField()
-            )
-        )
-        
-        return queryset
     
     def get_extra_context(self, request):
         context = super().get_extra_context(request)
@@ -182,18 +122,45 @@ def device_maintenance_tab(request, pk):
     recent_executions = models.MaintenanceExecution.objects.filter(
         maintenance_plan__device=device
     ).order_by('-scheduled_date')[:10]
-    
+
     # Count overdue maintenance
     overdue_count = sum(1 for plan in maintenance_plans if plan.is_overdue())
-    
+
     context = {
+        'target': device,
+        'target_kind': 'device',
+        'target_kwarg': 'device',
         'device': device,
         'object': device,  # For consistency with NetBox templates
         'maintenance_plans': maintenance_plans,
         'recent_executions': recent_executions,
         'overdue_count': overdue_count,
     }
-    
+
+    return render(request, 'netbox_maintenance_device/device_maintenance_tab.html', context)
+
+
+def virtualmachine_maintenance_tab(request, pk):
+    """Tab view for virtual machine maintenance history."""
+    vm = get_object_or_404(VirtualMachine, pk=pk)
+    maintenance_plans = models.MaintenancePlan.objects.filter(virtual_machine=vm).order_by('name')
+    recent_executions = models.MaintenanceExecution.objects.filter(
+        maintenance_plan__virtual_machine=vm
+    ).order_by('-scheduled_date')[:10]
+
+    overdue_count = sum(1 for plan in maintenance_plans if plan.is_overdue())
+
+    context = {
+        'target': vm,
+        'target_kind': 'virtualmachine',
+        'target_kwarg': 'virtual_machine',
+        'device': vm,  # Templates reuse the 'device' name for the target object.
+        'object': vm,
+        'maintenance_plans': maintenance_plans,
+        'recent_executions': recent_executions,
+        'overdue_count': overdue_count,
+    }
+
     return render(request, 'netbox_maintenance_device/device_maintenance_tab.html', context)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-maintenance-device"
-version = "1.3.1"
+version = "1.4.0"
 description = "NetBox plugin for device maintenance management with comprehensive REST API and Portuguese-BR support"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Closes #14 and #15.

Maintenance plans can now target either a Device or a VirtualMachine, and scheduling supports days/weeks/months/quarters/years with an optional anchor_date for drift-free calendar schedules (e.g. start of each quarter).

- models: nullable device + new virtual_machine FK with per-target conditional uniqueness; frequency_unit and anchor_date fields; get_next_maintenance_date() honors the anchor to avoid drift.
- migration 0003 adds the new schema, forward-compatible (existing day-based plans keep working with default frequency_unit='days').
- forms / tables / templates surface a unified Target column with Device / VM badges, plus a human-readable Frequency and Anchor.
- new VirtualMachine detail-page extension + dedicated VM tab view.
- API serializers and filtersets expose virtual_machine, frequency_unit, anchor_date and target_type; legacy device fields remain nullable for backward compatibility.
- version bumped to 1.4.0, CHANGELOG updated.