### PR TITLE
Fix plan form crash, badge contrast, target locking, schedule UX, sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-05-14
+
+### Fixed
+
+- **Crash on Maintenance Plan create/edit (`AttributeError: 'NoneType' object has no attribute 'get'`)** on NetBox 4.6 / Django 6.0. `NetBoxModelForm.clean()` modifies `self.cleaned_data` in place and does not always return it, so `super().clean()` was sometimes `None`. The plugin now reads from `self.cleaned_data` directly.
+- **Unreadable Device / VM badges** on the Maintenance Plans and Upcoming Maintenance tables. Bootstrap 5's `bg-secondary` / `bg-info` don't auto-set the foreground color in NetBox 4.6's theme, producing low-contrast text. Replaced with `text-bg-primary` (Device) and `text-bg-info` (VM), which set both background and contrasting text in one utility class.
+
+### Changed
+
+- **Plan form UX (#15 follow-up)**: relabeled the schedule fields to make calendar scheduling discoverable.
+  - `Frequency` → `Repeat every`
+  - `Frequency Unit` → `Unit`
+  - `Anchor Date` → `Calendar anchor (optional)` with a worked example in help text ("pick any 1st-of-month to schedule on the 1st of every month; pick 2026-01-01 with unit 'quarters' to land on Jan 1 / Apr 1 / Jul 1 / Oct 1").
+  - Grouped fields into `FieldSet`s (`Plan`, `Target`, `Schedule`, `Tags`) so the schedule controls read as one unit.
+- **Device / Virtual Machine field locking** on the plan form: picking one now disables the other client-side via a small static JS file (`static/netbox_maintenance_device/js/plan_target_toggle.js`, loaded via `form.Media`). The server-side XOR validation remains as a safety net.
+- **Upcoming & Overdue Maintenance**: added a filter bar above the table with **Status** (Overdue / Due Soon / Upcoming / On Track), **Maintenance Type**, and **Target** (Device / VM). Filtering happens in `UpcomingMaintenanceView.get_queryset` since the status is derived from the Python `days_until_due()` computation that can't be expressed as a single SQL predicate. Statistics cards continue to reflect the *unfiltered* totals so badges don't change with the current view slice.
+
+### Technical Details
+
+Files Modified / Added:
+
+- `netbox_maintenance_device/forms.py` — defensive `clean()`, fieldsets, relabeled schedule fields, `Media.js` reference.
+- `netbox_maintenance_device/static/netbox_maintenance_device/js/plan_target_toggle.js` — client-side toggle for Device / VM fields.
+- `netbox_maintenance_device/tables.py` — `text-bg-primary` / `text-bg-info` badges.
+- `netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceplan.html` — same badge swap on the detail page.
+- `netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceexecution.html` — same badge swap on the execution detail page.
+- `netbox_maintenance_device/templates/netbox_maintenance_device/upcoming_maintenance.html` — new filter form, empty-state copy updated.
+- `netbox_maintenance_device/views.py` — `_classify_plan` helper, status / type / target filtering in `UpcomingMaintenanceView.get_queryset`, stats remain based on the unfiltered base queryset.
+- `netbox_maintenance_device/__init__.py` / `pyproject.toml` — version bump to `1.4.1`.
+
 ## [1.4.0] - 2026-05-14
 
 ### Added

--- a/netbox_maintenance_device/__init__.py
+++ b/netbox_maintenance_device/__init__.py
@@ -5,7 +5,7 @@ class MaintenanceDeviceConfig(PluginConfig):
     name = 'netbox_maintenance_device'
     verbose_name = _('NetBox Device Maintenance')
     description = 'Manage device preventive and corrective maintenance with multilingual support'
-    version = '1.4.0'
+    version = '1.4.1'
     author = 'Diego Godoy'
     author_email = 'diegoalex-gdy@outlook.com'
     base_url = 'maintenance-device'
@@ -35,6 +35,6 @@ class MaintenanceDeviceConfig(PluginConfig):
         # to avoid issues during initial Django setup and collectstatic operations
         import logging
         logger = logging.getLogger(__name__)
-        logger.info("NetBox Maintenance Device v1.4.0 initialized successfully")
+        logger.info("NetBox Maintenance Device v1.4.1 initialized successfully")
 
 config = MaintenanceDeviceConfig

--- a/netbox_maintenance_device/forms.py
+++ b/netbox_maintenance_device/forms.py
@@ -7,6 +7,7 @@ from dcim.models import Device
 from netbox.filtersets import NetBoxModelFilterSet
 from netbox.forms import NetBoxModelForm
 from utilities.forms.fields import DynamicModelChoiceField
+from utilities.forms.rendering import FieldSet
 from virtualization.models import VirtualMachine
 
 from . import models
@@ -18,14 +19,42 @@ class MaintenancePlanForm(NetBoxModelForm):
         required=False,
         selector=True,
         label=_('Device'),
-        help_text=_("Pick a device — or pick a virtual machine below, not both."),
+        help_text=_("Pick a device — leave Virtual Machine empty."),
     )
     virtual_machine = DynamicModelChoiceField(
         queryset=VirtualMachine.objects.all(),
         required=False,
         selector=True,
         label=_('Virtual Machine'),
-        help_text=_("Pick a virtual machine — or pick a device above, not both."),
+        help_text=_("Pick a virtual machine — leave Device empty."),
+    )
+    frequency_days = forms.IntegerField(
+        min_value=1,
+        label=_('Repeat every'),
+        help_text=_("How many units between maintenances (e.g. '1' + 'Months' = monthly)."),
+    )
+    frequency_unit = forms.ChoiceField(
+        choices=models.MaintenancePlan.FREQUENCY_UNIT_CHOICES,
+        label=_('Unit'),
+        help_text=_("Days / weeks / months / quarters / years."),
+    )
+    anchor_date = forms.DateField(
+        required=False,
+        label=_('Calendar anchor (optional)'),
+        widget=forms.DateInput(attrs={'type': 'date'}),
+        help_text=_(
+            "Use this to lock the schedule to a calendar date and avoid drift. "
+            "Examples: pick any 1st-of-month to schedule on the 1st of every month; "
+            "pick 2026-01-01 with unit 'quarters' to land on Jan 1 / Apr 1 / Jul 1 / Oct 1. "
+            "Leave blank for a simple rolling interval from the last completion."
+        ),
+    )
+
+    fieldsets = (
+        FieldSet('name', 'description', 'maintenance_type', 'is_active', name=_('Plan')),
+        FieldSet('device', 'virtual_machine', name=_('Target')),
+        FieldSet('frequency_days', 'frequency_unit', 'anchor_date', name=_('Schedule')),
+        FieldSet('tags', name=_('Tags')),
     )
 
     class Meta:
@@ -34,12 +63,17 @@ class MaintenancePlanForm(NetBoxModelForm):
             'device', 'virtual_machine', 'name', 'description', 'maintenance_type',
             'frequency_days', 'frequency_unit', 'anchor_date', 'is_active', 'tags',
         ]
-        widgets = {
-            'anchor_date': forms.DateInput(attrs={'type': 'date'}),
-        }
+
+    class Media:
+        # Disables the other target field when one is selected.
+        js = ('netbox_maintenance_device/js/plan_target_toggle.js',)
 
     def clean(self):
-        cleaned_data = super().clean()
+        # NetBoxModelForm.clean() modifies self.cleaned_data in place but may not
+        # return it (Django allows either pattern), so we read from self.cleaned_data
+        # directly to avoid a NoneType crash.
+        super().clean()
+        cleaned_data = self.cleaned_data or {}
         device = cleaned_data.get('device')
         vm = cleaned_data.get('virtual_machine')
         if device and vm:

--- a/netbox_maintenance_device/static/netbox_maintenance_device/js/plan_target_toggle.js
+++ b/netbox_maintenance_device/static/netbox_maintenance_device/js/plan_target_toggle.js
@@ -1,0 +1,78 @@
+// Disables the "other" target field when one of (Device, Virtual Machine) is selected,
+// so users can't accidentally fill both. The server still enforces the XOR rule.
+
+(function () {
+    'use strict';
+
+    function getCurrentValue(field) {
+        // DynamicModelChoiceField hides the underlying <select>; its `.value` is the
+        // canonical source of truth even when the UI widget is a custom combobox.
+        return field && field.value ? field.value.toString().trim() : '';
+    }
+
+    function findRow(field) {
+        // The form layout wraps each field in a row/group — disabling the row also
+        // dims the label and the API-search input that DynamicModelChoiceField renders.
+        return field.closest('.row, .field-group, .mb-3, fieldset, .form-group') || field.parentElement;
+    }
+
+    function setDisabled(field, disabled) {
+        if (!field) return;
+
+        field.disabled = disabled;
+
+        var row = findRow(field);
+        if (row) {
+            row.classList.toggle('opacity-50', disabled);
+            // Disable any nested inputs (e.g. the API-driven combobox uses a sibling
+            // text input). `:scope` keeps this scoped to the current row.
+            row.querySelectorAll(':scope input, :scope select, :scope button').forEach(function (el) {
+                if (el !== field) {
+                    el.disabled = disabled;
+                }
+            });
+        }
+    }
+
+    function syncFields(deviceField, vmField) {
+        var deviceVal = getCurrentValue(deviceField);
+        var vmVal = getCurrentValue(vmField);
+
+        if (deviceVal && !vmVal) {
+            setDisabled(vmField, true);
+            setDisabled(deviceField, false);
+        } else if (vmVal && !deviceVal) {
+            setDisabled(deviceField, true);
+            setDisabled(vmField, false);
+        } else {
+            setDisabled(deviceField, false);
+            setDisabled(vmField, false);
+        }
+    }
+
+    function init() {
+        var deviceField = document.getElementById('id_device');
+        var vmField = document.getElementById('id_virtual_machine');
+
+        if (!deviceField || !vmField) {
+            return;
+        }
+
+        // Re-sync on any change to either field. `change` covers manual edits and
+        // DynamicModelChoiceField's programmatic value updates; `input` catches typed
+        // changes that some widgets fire before `change`.
+        ['change', 'input'].forEach(function (evt) {
+            deviceField.addEventListener(evt, function () { syncFields(deviceField, vmField); });
+            vmField.addEventListener(evt, function () { syncFields(deviceField, vmField); });
+        });
+
+        // Run once at page load — handles the edit flow where one field is already set.
+        syncFields(deviceField, vmField);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/netbox_maintenance_device/tables.py
+++ b/netbox_maintenance_device/tables.py
@@ -25,11 +25,11 @@ def _render_target_type(record):
     target_type = record.target_type
     if target_type == 'device':
         return mark_safe(
-            '<span class="badge bg-secondary"><i class="mdi mdi-server"></i> Device</span>'
+            '<span class="badge text-bg-primary"><i class="mdi mdi-server"></i> Device</span>'
         )
     if target_type == 'virtualmachine':
         return mark_safe(
-            '<span class="badge bg-info"><i class="mdi mdi-monitor"></i> VM</span>'
+            '<span class="badge text-bg-info"><i class="mdi mdi-monitor"></i> VM</span>'
         )
     return '-'
 

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceexecution.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceexecution.html
@@ -17,9 +17,9 @@
                             {% if target %}
                                 <a href="{{ target.get_absolute_url }}">{{ target }}</a>
                                 {% if object.maintenance_plan.target_type == 'device' %}
-                                    <span class="badge bg-secondary ml-1"><i class="mdi mdi-server"></i> Device</span>
+                                    <span class="badge text-bg-primary ml-1"><i class="mdi mdi-server"></i> Device</span>
                                 {% else %}
-                                    <span class="badge bg-info ml-1"><i class="mdi mdi-monitor"></i> VM</span>
+                                    <span class="badge text-bg-info ml-1"><i class="mdi mdi-monitor"></i> VM</span>
                                 {% endif %}
                             {% else %}
                                 —

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceplan.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/maintenanceplan.html
@@ -12,9 +12,9 @@
                         {% if object.target %}
                             <a href="{{ object.target.get_absolute_url }}">{{ object.target }}</a>
                             {% if object.target_type == 'device' %}
-                                <span class="badge bg-secondary ml-1"><i class="mdi mdi-server"></i> Device</span>
+                                <span class="badge text-bg-primary ml-1"><i class="mdi mdi-server"></i> Device</span>
                             {% else %}
-                                <span class="badge bg-info ml-1"><i class="mdi mdi-monitor"></i> VM</span>
+                                <span class="badge text-bg-info ml-1"><i class="mdi mdi-monitor"></i> VM</span>
                             {% endif %}
                         {% else %}
                             —

--- a/netbox_maintenance_device/templates/netbox_maintenance_device/upcoming_maintenance.html
+++ b/netbox_maintenance_device/templates/netbox_maintenance_device/upcoming_maintenance.html
@@ -12,51 +12,59 @@
 {% block content %}
 <div class="row">
     <div class="col col-md-12">
-        <!-- Statistics Cards -->
+        <!-- Statistics Cards — click to filter -->
         <div class="row mb-3">
             <div class="col-sm-6 col-lg-3 mb-2">
-                <div class="card border-danger">
-                    <div class="card-body text-center p-3">
-                        <div class="text-danger mb-1">
-                            <i class="mdi mdi-alert-circle mdi-24px"></i>
+                <a href="?status=overdue" class="text-decoration-none">
+                    <div class="card border-danger {% if selected_status == 'overdue' %}bg-danger bg-opacity-10{% endif %}">
+                        <div class="card-body text-center p-3">
+                            <div class="text-danger mb-1">
+                                <i class="mdi mdi-alert-circle mdi-24px"></i>
+                            </div>
+                            <h3 class="mb-1 text-danger">{{ overdue_count }}</h3>
+                            <small class="text-muted">{% trans "Overdue" %}</small>
                         </div>
-                        <h3 class="mb-1 text-danger">{{ overdue_count }}</h3>
-                        <small class="text-muted">{% trans "Overdue" %}</small>
                     </div>
-                </div>
+                </a>
             </div>
             <div class="col-sm-6 col-lg-3 mb-2">
-                <div class="card border-warning">
-                    <div class="card-body text-center p-3">
-                        <div class="text-warning mb-1">
-                            <i class="mdi mdi-clock-alert mdi-24px"></i>
+                <a href="?status=due_soon" class="text-decoration-none">
+                    <div class="card border-warning {% if selected_status == 'due_soon' %}bg-warning bg-opacity-10{% endif %}">
+                        <div class="card-body text-center p-3">
+                            <div class="text-warning mb-1">
+                                <i class="mdi mdi-clock-alert mdi-24px"></i>
+                            </div>
+                            <h3 class="mb-1 text-warning">{{ due_soon_count }}</h3>
+                            <small class="text-muted">{% trans "Due Soon (≤7 days)" %}</small>
                         </div>
-                        <h3 class="mb-1 text-warning">{{ due_soon_count }}</h3>
-                        <small class="text-muted">{% trans "Due Soon (≤7 days)" %}</small>
                     </div>
-                </div>
+                </a>
             </div>
             <div class="col-sm-6 col-lg-3 mb-2">
-                <div class="card border-info">
-                    <div class="card-body text-center p-3">
-                        <div class="text-info mb-1">
-                            <i class="mdi mdi-calendar-clock mdi-24px"></i>
+                <a href="?status=upcoming" class="text-decoration-none">
+                    <div class="card border-info {% if selected_status == 'upcoming' %}bg-info bg-opacity-10{% endif %}">
+                        <div class="card-body text-center p-3">
+                            <div class="text-info mb-1">
+                                <i class="mdi mdi-calendar-clock mdi-24px"></i>
+                            </div>
+                            <h3 class="mb-1 text-info">{{ upcoming_count }}</h3>
+                            <small class="text-muted">{% trans "Upcoming (8-30 days)" %}</small>
                         </div>
-                        <h3 class="mb-1 text-info">{{ upcoming_count }}</h3>
-                        <small class="text-muted">{% trans "Upcoming (8-30 days)" %}</small>
                     </div>
-                </div>
+                </a>
             </div>
             <div class="col-sm-6 col-lg-3 mb-2">
-                <div class="card border-success">
-                    <div class="card-body text-center p-3">
-                        <div class="text-success mb-1">
-                            <i class="mdi mdi-check-circle mdi-24px"></i>
+                <a href="?status=on_track" class="text-decoration-none">
+                    <div class="card border-success {% if selected_status == 'on_track' %}bg-success bg-opacity-10{% endif %}">
+                        <div class="card-body text-center p-3">
+                            <div class="text-success mb-1">
+                                <i class="mdi mdi-check-circle mdi-24px"></i>
+                            </div>
+                            <h3 class="mb-1 text-success">{{ on_track_count }}</h3>
+                            <small class="text-muted">{% trans "On Track (>30 days)" %}</small>
                         </div>
-                        <h3 class="mb-1 text-success">{{ on_track_count }}</h3>
-                        <small class="text-muted">{% trans "On Track (>30 days)" %}</small>
                     </div>
-                </div>
+                </a>
             </div>
         </div>
         
@@ -73,10 +81,51 @@
         </div>
         {% endif %}
         
+        <div class="card mb-3">
+            <div class="card-body">
+                <form method="get" class="row g-2 align-items-end">
+                    <div class="col-md-3">
+                        <label for="filter-status" class="form-label small mb-1">{% trans "Status" %}</label>
+                        <select id="filter-status" name="status" class="form-select form-select-sm">
+                            <option value="">{% trans "All statuses" %}</option>
+                            {% for value, label in status_choices %}
+                                <option value="{{ value }}" {% if selected_status == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label for="filter-type" class="form-label small mb-1">{% trans "Maintenance Type" %}</label>
+                        <select id="filter-type" name="maintenance_type" class="form-select form-select-sm">
+                            <option value="">{% trans "All types" %}</option>
+                            {% for value, label in maintenance_type_choices %}
+                                <option value="{{ value }}" {% if selected_maintenance_type == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label for="filter-target" class="form-label small mb-1">{% trans "Target" %}</label>
+                        <select id="filter-target" name="target_type" class="form-select form-select-sm">
+                            <option value="">{% trans "Devices and VMs" %}</option>
+                            <option value="device" {% if selected_target_type == 'device' %}selected{% endif %}>{% trans "Devices only" %}</option>
+                            <option value="virtualmachine" {% if selected_target_type == 'virtualmachine' %}selected{% endif %}>{% trans "Virtual machines only" %}</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3 d-flex gap-2">
+                        <button type="submit" class="btn btn-primary btn-sm">
+                            <i class="mdi mdi-filter"></i> {% trans "Apply" %}
+                        </button>
+                        <a href="{% url 'plugins:netbox_maintenance_device:upcoming_maintenance' %}" class="btn btn-outline-secondary btn-sm">
+                            <i class="mdi mdi-close"></i> {% trans "Clear" %}
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+
         <div class="card">
             <h5 class="card-header">
                 <i class="mdi mdi-calendar-alert"></i> {% trans "Upcoming & Overdue Maintenance" %}
-                <span class="badge badge-secondary float-right">{{ table.data|length }}</span>
+                <span class="badge text-bg-secondary float-end">{{ table.data|length }}</span>
             </h5>
             <div class="card-body">
                 {% if table.data %}
@@ -84,7 +133,7 @@
                 {% else %}
                     <div class="alert alert-info">
                         <i class="mdi mdi-information"></i>
-                        {% trans "No upcoming or overdue maintenance found." %}
+                        {% trans "No maintenance plans match the current filter." %}
                     </div>
                 {% endif %}
             </div>

--- a/netbox_maintenance_device/views.py
+++ b/netbox_maintenance_device/views.py
@@ -60,58 +60,95 @@ class MaintenanceExecutionChangeLogView(generic.ObjectChangeLogView):
     queryset = models.MaintenanceExecution.objects.all()
 
 
+UPCOMING_STATUS_CHOICES = [
+    ('overdue', _('Overdue')),
+    ('due_soon', _('Due Soon (≤ 7 days)')),
+    ('upcoming', _('Upcoming (8–30 days)')),
+    ('on_track', _('On Track (> 30 days)')),
+]
+
+
+def _classify_plan(days):
+    """Map days-until-due to a status bucket used by the upcoming view filter."""
+    if days is None:
+        return None
+    if days < 0:
+        return 'overdue'
+    if days <= 7:
+        return 'due_soon'
+    if days <= 30:
+        return 'upcoming'
+    return 'on_track'
+
+
 class UpcomingMaintenanceView(generic.ObjectListView):
-    """View for upcoming and overdue maintenance"""
+    """View for upcoming and overdue maintenance."""
     queryset = models.MaintenancePlan.objects.filter(is_active=True)
     table = tables.UpcomingMaintenanceTable
     template_name = 'netbox_maintenance_device/upcoming_maintenance.html'
-    
-    def get_queryset(self, request):
-        # Active plans only. Next-due dates are computed in Python because the
-        # schedule logic now spans multiple units (days/weeks/months/quarters/years)
-        # and an optional anchor date, which can't be expressed cleanly as a single
-        # SQL expression. Tables fall back to model methods when the annotation
-        # fields are missing.
+
+    def _base_queryset(self, request):
         return (
-            super().get_queryset(request)
+            models.MaintenancePlan.objects.filter(is_active=True)
             .select_related('device', 'virtual_machine')
             .prefetch_related('executions')
         )
-    
+
+    def get_queryset(self, request):
+        # Status, maintenance_type and target_type filters are applied here because
+        # the status comes from a Python computation (next-due across units and
+        # optional anchors) that can't be expressed as a single SQL predicate.
+        qs = self._base_queryset(request)
+
+        maintenance_type = request.GET.get('maintenance_type')
+        if maintenance_type in {choice for choice, _label in models.MaintenancePlan.MAINTENANCE_TYPE_CHOICES}:
+            qs = qs.filter(maintenance_type=maintenance_type)
+
+        target_type = request.GET.get('target_type')
+        if target_type == 'device':
+            qs = qs.filter(device__isnull=False)
+        elif target_type == 'virtualmachine':
+            qs = qs.filter(virtual_machine__isnull=False)
+
+        status_filter = request.GET.get('status')
+        if status_filter in {key for key, _label in UPCOMING_STATUS_CHOICES}:
+            matching_pks = [
+                plan.pk for plan in qs
+                if _classify_plan(plan.days_until_due()) == status_filter
+            ]
+            qs = qs.filter(pk__in=matching_pks)
+
+        return qs
+
     def get_extra_context(self, request):
         context = super().get_extra_context(request)
-        
-        # Calculate statistics for all plans
-        queryset = self.get_queryset(request)
-        
-        overdue_count = 0
-        due_soon_count = 0
-        upcoming_count = 0
-        on_track_count = 0
-        
-        for plan in queryset:
-            # Use annotated field if available
-            if hasattr(plan, '_days_until'):
-                days = plan._days_until
-            else:
-                days = plan.days_until_due()
-            
-            if days is not None:
-                if days < 0:
-                    overdue_count += 1
-                elif days <= 7:
-                    due_soon_count += 1
-                elif days <= 30:
-                    upcoming_count += 1
-                else:
-                    on_track_count += 1
-        
-        context['overdue_count'] = overdue_count
-        context['due_soon_count'] = due_soon_count
-        context['upcoming_count'] = upcoming_count
-        context['on_track_count'] = on_track_count
-        context['total_plans'] = queryset.count()
-        
+
+        # Stats use the unfiltered base set so badges always reflect the whole picture,
+        # not the slice the user is currently viewing.
+        overdue_count = due_soon_count = upcoming_count = on_track_count = 0
+        for plan in self._base_queryset(request):
+            bucket = _classify_plan(plan.days_until_due())
+            if bucket == 'overdue':
+                overdue_count += 1
+            elif bucket == 'due_soon':
+                due_soon_count += 1
+            elif bucket == 'upcoming':
+                upcoming_count += 1
+            elif bucket == 'on_track':
+                on_track_count += 1
+
+        context.update({
+            'overdue_count': overdue_count,
+            'due_soon_count': due_soon_count,
+            'upcoming_count': upcoming_count,
+            'on_track_count': on_track_count,
+            'total_plans': overdue_count + due_soon_count + upcoming_count + on_track_count,
+            'status_choices': UPCOMING_STATUS_CHOICES,
+            'maintenance_type_choices': models.MaintenancePlan.MAINTENANCE_TYPE_CHOICES,
+            'selected_status': request.GET.get('status', ''),
+            'selected_maintenance_type': request.GET.get('maintenance_type', ''),
+            'selected_target_type': request.GET.get('target_type', ''),
+        })
         return context
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-maintenance-device"
-version = "1.4.0"
+version = "1.4.1"
 description = "NetBox plugin for device maintenance management with comprehensive REST API and Portuguese-BR support"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
…tus filter

- Fix AttributeError on POST /maintenance-plans/add/ on NetBox 4.6 / Django 6.0: NetBoxModelForm.clean() doesn't always return cleaned_data, so the prior super().clean().get(...) chain crashed. Read from self.cleaned_data instead.
- Fix unreadable Device / VM badges (grey bg + invisible white text) by switching to Bootstrap 5's text-bg-primary / text-bg-info utilities.
- Lock Device / VM fields client-side: picking one now disables the other. Server-side XOR validation stays as a safety net.
- Simplify the schedule UX on the plan form: relabel to Repeat every / Unit / Calendar anchor (optional), group with FieldSets, and add a worked example in the help text for the "1st of every month" use case.
- Add Status / Maintenance Type / Target filters on the Upcoming & Overdue Maintenance page. Status is computed in Python (multi-unit + anchored schedules can't be expressed as a single SQL predicate); the stats cards remain based on the unfiltered base set.
- Bump to 1.4.1, update CHANGELOG.